### PR TITLE
Handle group privacy (and other) errors

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -13,9 +13,20 @@ function chooseAWinner (confirmedMembersList) {
 
 function excludeHosts (membersList) {
   return new Promise((resolve, reject) => {
-    const membersListWithoutHosts = membersList.filter(m => !m.member.event_context.host)
+    if (Array.isArray(membersList)) {
+      const membersListWithoutHosts = membersList.filter(m => !m.member.event_context.host)
 
-    resolve(membersListWithoutHosts)
+      return resolve(membersListWithoutHosts)
+    }
+
+    if (membersList.errors && membersList.errors.length) {
+      const firstError = membersList.errors.shift()
+      if (firstError.message) {
+        return reject(new Error(firstError.message))
+      }
+    }
+
+    return reject(new Error('Unknown error encountered with the Meetup API.'))
   })
 }
 


### PR DESCRIPTION
A few things to note here:

* The data in the response from the API is an array of error objects. In this case, I simply relay the message text from the first one to the consumer and ignore the rest. One could easily reduce over `membersList.errors` and construct some kind of array of paired down error objects or strings, if desired.
* I don't know what other scenarios might trigger this response format from the API, but this will catch all of those (not just the privacy error that I sought out to fix).
* If `membersList` is not an array as expected and the response is not this type of error response, I took the liberty of rejecting with a generic error message (as a catch-all). Feel free to rephrase or whatever.
