### PR TITLE
fix(browser): resolve proper event data

### DIFF
--- a/lib/shim/modules/get-event-data.js
+++ b/lib/shim/modules/get-event-data.js
@@ -5,7 +5,7 @@ function getData (apiUrl, meetupName, eventId) {
     const url = apiUrl.replace('{{meetupName}}', meetupName).replace('{{eventId}}', eventId)
 
     $.getJSON(url)
-      .done(results => resolve(results.data))
+      .done(results => resolve(results))
       .fail(error => reject(error))
   })
 }


### PR DESCRIPTION
`meetupRandomizer.run` errors in the browser because jQuery's `getJSON` returns the data directly (not nested in a `data` property) but the browser shim for `getEventData` incorrectly resolves with `results.data` so further processing of said data fails.

I know this is ancient and needs other updates, but I ran into this bug and figured I'd submit a quick fix. 🙂 